### PR TITLE
removed redundant xhr

### DIFF
--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -2,7 +2,6 @@
  * Module dependencies
  */
 
-var XMLHttpRequest = require('xmlhttprequest');
 var XHR = require('./polling-xhr');
 var JSONP = require('./polling-jsonp');
 var websocket = require('./websocket');
@@ -22,7 +21,6 @@ exports.websocket = websocket;
  */
 
 function polling(opts){
-  var xhr;
   var xd = false;
   var xs = false;
   var jsonp = false !== opts.jsonp;
@@ -42,9 +40,8 @@ function polling(opts){
 
   opts.xdomain = xd;
   opts.xscheme = xs;
-  xhr = new XMLHttpRequest(opts);
 
-  if ('open' in xhr && !opts.forceJSONP) {
+  if (!opts.forceJSONP) {
     return new XHR(opts);
   } else {
     if (!jsonp) throw new Error('JSONP disabled');


### PR DESCRIPTION
constructor `xmlhttprequest` define by default `open` function and `xhr` have not any other meaning. That is why `if ('open' in xhr && !opts.forceJSONP)` is redundant.