### PR TITLE
fix default port detection when host is specified

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -58,7 +58,12 @@ function Socket(uri, opts){
   if (opts.host) {
     var pieces = opts.host.split(':');
     opts.hostname = pieces.shift();
-    if (pieces.length) opts.port = pieces.pop();
+    if (pieces.length) {
+      opts.port = pieces.pop();
+    } else if (!opts.port) {
+      // if no port is specified manually, use the protocol default
+      opts.port = self.secure ? '443' : '80';
+    }
   }
 
   self.agent = opts.agent || false;

--- a/test/engine.io-client.js
+++ b/test/engine.io-client.js
@@ -8,4 +8,24 @@ describe('engine.io-client', function () {
     expect(eio.protocol).to.be.a('number');
   });
 
+  it('should properly parse http uri without port', function() {
+    var server = eio('http://localhost');
+    expect(server.port).to.be('80');
+  });
+
+  it('should properly parse https uri without port', function() {
+    var server = eio('https://localhost');
+    expect(server.port).to.be('443');
+  });
+
+  it('should properly parse wss uri without port', function() {
+    var server = eio('wss://localhost');
+    expect(server.port).to.be('443');
+  });
+
+  it('should properly parse wss uri with port', function() {
+    var server = eio('wss://localhost:2020');
+    expect(server.port).to.be('2020');
+  });
+
 });


### PR DESCRIPTION
This fixes an issue when a full url is specified (i.e.
http://service.com) the port would be the port from the page and not the
uri string. This is easily exposed if using external engine.io servers
on a page served up by localhost:3000 or similar from a development
page.