### PR TITLE
Bump zuul and use ngrok

### DIFF
--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,5 +1,9 @@
 ui: mocha-bdd
 server: ./test/support/server.js
+tunnel:
+  type: ngrok
+  authtoken: JnawIksKFkXQzrxSjIjQ
+  proto: tcp
 browsers:
   - name: chrome
     version: 29..latest

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "express": "3.4.8",
     "istanbul": "0.2.3",
     "mocha": "1.16.2",
-    "zuul": "rase-/zuul#9d3a02"
+    "zuul": "1.17.1",
+    "zuul-ngrok": "2.0.0"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
Uses the new pluggable tunnel feature from Zuul.

In addition by bumping we get code coverage in the browser when running locally.