### PR TITLE
[deps] Bump ws, 0.7 prevents build failures that could be caused by bina...

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "dependencies": {
     "has-cors": "1.0.3",
-    "ws": "0.6.5",
+    "ws": "0.7.1",
     "xmlhttprequest": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
     "component-emitter": "1.1.2",
     "indexof": "0.0.1",


### PR DESCRIPTION
[deps] Bump ws, 0.7 prevents build failures that could be caused by binary add-ons. 