### PR TITLE
Fix error when passing WebSocket#send the second argument on Safari

### DIFF
--- a/lib/transports/websocket.js
+++ b/lib/transports/websocket.js
@@ -156,7 +156,12 @@ WS.prototype.write = function(packets){
       //have a chance of informing us about it yet, in that case send will
       //throw an error
       try {
-        self.ws.send(data, packet.options);
+        if (global.WebSocket && self.ws instanceof global.WebSocket) {
+          // TypeError is thrown when passing the second argument on Safari
+          self.ws.send(data);
+        } else {
+          self.ws.send(data, packet.options);
+        }
       } catch (e){
         debug('websocket closed before onclose event');
       }


### PR DESCRIPTION
WebSocket throws `TypeError` somehow on Safari/Midori as follows. 

```js
var ws = new WebSocket('http://localhost:3000');
ws.send('hi', undefined); // TypeError
```

This PR fixes the cause of https://github.com/Automattic/socket.io/issues/2000 .