### PR TITLE
the 'ok' string isn't a very useful XHR response

### DIFF
--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -346,7 +346,7 @@ Request.prototype.onLoad = function(){
       if (!this.supportsBinary) {
         data = this.xhr.responseText;
       } else {
-        data = 'ok';
+        data = String.fromCharCode.apply(null, new Uint8Array(this.xhr.response));
       }
     }
   } catch (e) {


### PR DESCRIPTION
Since this is a text/plain response and we forced XHR to return an arraybuffer earlier, make it text again instead of an 'ok' :)