### PR TITLE
socket: fix host parsing for IPv6 URLs

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -55,14 +55,21 @@ function Socket(uri, opts){
     (global.location && 'https:' == location.protocol);
 
   if (opts.host) {
-    var pieces = opts.host.split(':');
-    opts.hostname = pieces.shift();
-    if (pieces.length) {
-      opts.port = pieces.pop();
-    } else if (!opts.port) {
-      // if no port is specified manually, use the protocol default
-      opts.port = this.secure ? '443' : '80';
+    var match = opts.host.match(/(\[.+\])(.+)?/)
+      , pieces;
+
+    if (match) {
+      opts.hostname = match[1];
+      if (match[2]) opts.port = match[2].slice(1);
+    } else {
+      pieces = opts.host.split(':');
+      opts.hostname = pieces.shift();
+      if (pieces.length) opts.port = pieces.pop();
     }
+
+    // if `host` does not include a port and one is not specified manually,
+    // use the protocol default
+    if (!opts.port) opts.port = this.secure ? '443' : '80';
   }
 
   this.agent = opts.agent || false;

--- a/test/engine.io-client.js
+++ b/test/engine.io-client.js
@@ -44,4 +44,34 @@ describe('engine.io-client', function () {
     client.close();
   });
 
+  it('should properly parse an IPv6 host without port (1/2)', function(done) {
+    var client = eio({ host: '[::1]' });
+    client.on('close', function() {
+      done();
+    });
+    expect(client.hostname).to.be('[::1]');
+    expect(client.port).to.be('80');
+    client.close();
+  });
+
+  it('should properly parse an IPv6 host without port (2/2)', function(done) {
+    var client = eio({ secure: true, host: '[::1]:' });
+    client.on('close', function() {
+      done();
+    });
+    expect(client.hostname).to.be('[::1]');
+    expect(client.port).to.be('443');
+    client.close();
+  });
+
+  it('should properly parse an IPv6 host with port', function(done) {
+    var client = eio({ host: '[::1]:8080' });
+    client.on('close', function() {
+      done();
+    });
+    expect(client.hostname).to.be('[::1]');
+    expect(client.port).to.be('8080');
+    client.close();
+  });
+
 });


### PR DESCRIPTION
This fixes an issue that was preventing the `hostname` and `port` of the connection URL from being parsed correctly when using a literal IPv6 address (e.g. `http://[::1]:8080/`).

Before:
```js
> var io = require('./');
undefined
> var socket = io({ host: '[::1]' });
undefined
> socket.hostname
'['
> socket.port
'1]'
```

After:
```js
> var io = require('./');
undefined
> var socket = io({ host: '[::1]' });
undefined
> socket.hostname
'[::1]'
> socket.port
'80'
```

There is already a similar pull request: #377.