### PR TITLE
Switched xmlhttprequest dependency to a versioned one

### DIFF
--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -2,7 +2,7 @@
  * Module dependencies
  */
 
-var XMLHttpRequest = require('xmlhttprequest');
+var XMLHttpRequest = require('xmlhttprequest-ssl');
 var XHR = require('./polling-xhr');
 var JSONP = require('./polling-jsonp');
 var websocket = require('./websocket');

--- a/lib/transports/polling-xhr.js
+++ b/lib/transports/polling-xhr.js
@@ -2,7 +2,7 @@
  * Module requirements.
  */
 
-var XMLHttpRequest = require('xmlhttprequest');
+var XMLHttpRequest = require('xmlhttprequest-ssl');
 var Polling = require('./polling');
 var Emitter = require('component-emitter');
 var inherit = require('component-inherit');

--- a/lib/transports/polling.js
+++ b/lib/transports/polling.js
@@ -19,7 +19,7 @@ module.exports = Polling;
  */
 
 var hasXHR2 = (function() {
-  var XMLHttpRequest = require('xmlhttprequest');
+  var XMLHttpRequest = require('xmlhttprequest-ssl');
   var xhr = new XMLHttpRequest({ xdomain: false });
   return null != xhr.responseType;
 })();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "has-cors": "1.0.3",
     "ws": "0.7.2",
-    "xmlhttprequest": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
+    "xmlhttprequest-ssl": "1.5.1",
     "component-emitter": "1.1.2",
     "indexof": "0.0.1",
     "engine.io-parser": "1.2.1",


### PR DESCRIPTION
Switched xmlhttprequest dependency to a versioned one. Because a pull request is not being made for the changes in the old forked version, I published the forked version (with some added fixes to make the tests run again) to a new npm module: xmlhttprequest-ssl. This module can be used until the changes are finally merged into the original xmlhttprequest module.
Please view the [xmlhttprequest-ssl README.md](https://github.com/mjwwit/node-XMLHttpRequest/blob/master/README.md) for more info.