### PR TITLE
Fix browserify setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test": "make test"
   },
   "browser": {
-    "xmlhttprequest": "./lib/xmlhttprequest.js"
+    "xmlhttprequest-ssl": "./lib/xmlhttprequest.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We have to fix the browser field of package.json to replace xmlhttprequest-ssl for browser.

Related: https://github.com/Automattic/engine.io-client/pull/396